### PR TITLE
Draft visibility

### DIFF
--- a/apps/challenges/auth.py
+++ b/apps/challenges/auth.py
@@ -15,4 +15,9 @@ class SubmissionBackend(object):
             # Owners can edit and delete their own submissions
             if obj is not None and user_obj == obj.created_by.user:
                 return True
+        if perm == 'challenges.view_submission' and obj is not None:
+            # Live, non-draft submissions are visible to anyone. Other
+            # submissions are visible only to admins and their owners
+            return ((obj.is_live and not obj.is_draft) or
+                    user_obj == obj.created_by.user)
         return False

--- a/apps/challenges/models.py
+++ b/apps/challenges/models.py
@@ -64,20 +64,29 @@ class Challenge(BaseModel):
     def __unicode__(self):
         return self.title
     
-    def get_absolute_url(self):
-        """Return this challenge's URL.
+    def _lookup_url(self, view_name, kwargs=None):
+        """Look up a URL related to this challenge.
         
         Note that this needs to account both for an Ignite-style URL structure,
         where there is a single challenge for the entire site, and sites where
         there are multiple challenges.
         
         """
+        if kwargs is None:
+            kwargs = {}
         try:
-            # Match for a single-challenge site if we can
-            return reverse('challenge_show')
+            return reverse(view_name, kwargs=kwargs)
         except NoReverseMatch:
-            kwargs = {'project': self.project.slug, 'slug': self.slug}
-            return reverse('challenge_show', kwargs=kwargs)
+            kwargs.update({'project': self.project.slug, 'slug': self.slug})
+            return reverse(view_name, kwargs=kwargs)
+    
+    def get_absolute_url(self):
+        """Return this challenge's URL."""
+        return self._lookup_url('challenge_show')
+    
+    def get_entries_url(self):
+        """Return the URL for this challenge's entry list."""
+        return self._lookup_url('entries_all')
 
 
 class PhaseManager(BaseModelManager):
@@ -241,7 +250,7 @@ class Submission(BaseModel):
     def __unicode__(self):
         return self.title
     
-    def _lookup_url(self, view_name, kwargs):
+    def _lookup_url(self, view_name, kwargs=None):
         """Look up a URL related to this submission.
         
         Note that this needs to account both for an Ignite-style URL structure,
@@ -249,6 +258,8 @@ class Submission(BaseModel):
         there are multiple challenges.
         
         """
+        if kwargs is None:
+            kwargs = {}
         try:
             return reverse(view_name, kwargs=kwargs)
         except NoReverseMatch:

--- a/apps/challenges/models.py
+++ b/apps/challenges/models.py
@@ -285,6 +285,10 @@ class Submission(BaseModel):
         return any(user.has_perm(permission_name, obj=obj)
                    for obj in [None, self])
     
+    def visible_to(self, user):
+        """Return True if the user provided can see this entry."""
+        return self._permission_check(user, 'challenges.view_submission')
+    
     def editable_by(self, user):
         """Return True if the user provided can edit this entry."""
         return self._permission_check(user, 'challenges.edit_submission')

--- a/apps/ignite/tests/test_views.py
+++ b/apps/ignite/tests/test_views.py
@@ -1,0 +1,44 @@
+from django.core.urlresolvers import reverse
+from django.core.cache import cache
+import test_utils
+
+from challenges.models import Submission
+from challenges.tests.fixtures import (challenge_setup, challenge_teardown,
+                                       create_submissions)
+from ignite.tests.decorators import ignite_only
+
+
+class SplashViewTest(test_utils.TestCase):
+    
+    def setUp(self):
+        challenge_setup()
+        cache.clear()
+    
+    def tearDown(self):
+        challenge_teardown()
+    
+    @ignite_only
+    def test_splash_page(self):
+        response = self.client.get(reverse('challenge_show'))
+        self.assertEqual(response.status_code, 200)
+    
+    @ignite_only
+    def test_splash_page_with_entries(self):
+        create_submissions(30)
+        response = self.client.get(reverse('challenge_show'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['entries']), 10)
+    
+    @ignite_only
+    def test_splash_draft_entries(self):
+        """Test draft entries aren't shown on the splash page."""
+        create_submissions(3)
+        submissions = Submission.objects.all()
+        hidden = submissions[0]
+        hidden.is_draft = True
+        hidden.save()
+        
+        response = self.client.get(reverse('challenge_show'))
+        self.assertEqual(set(response.context['entries']),
+                         set(submissions[1:]))
+        

--- a/apps/ignite/views.py
+++ b/apps/ignite/views.py
@@ -9,13 +9,10 @@ def splash(request, project, slug, template_name='challenges/show.html'):
     """Show an individual project challenge."""
     project = get_object_or_404(Project, slug=project)
     challenge = get_object_or_404(project.challenge_set, slug=slug)
-    entries = Submission.objects.filter(
-        phase__challenge=challenge
-    ).exclude(
-        is_draft=True
-    ).extra(
-        order_by="?"
-    )
+    entries = (Submission.objects.visible()
+                                 .filter(phase__challenge=challenge)
+                                 .order_by("?"))
+    
     return jingo.render(request, 'ignite/splash.html', {
         'challenge': challenge,
         'project': project,


### PR DESCRIPTION
Hide draft submissions from public view (both from lists and from direct access), as raised in issue #16.
