### PR TITLE
Remove the 'is_live' field from submissions.

### DIFF
--- a/apps/challenges/admin.py
+++ b/apps/challenges/admin.py
@@ -46,10 +46,10 @@ class ExclusionFlagInline(admin.StackedInline):
 class SubmissionAdmin(admin.ModelAdmin):
     
     model = Submission
-    list_display = ('title', 'created_by', 'category', 'phase', 'is_live',
+    list_display = ('title', 'created_by', 'category', 'phase', 'is_draft',
                     'is_winner', 'excluded', 'judge_assignment',
                     'judgement_count')
-    list_filter = ('category', 'is_live', 'is_winner')
+    list_filter = ('category', 'is_draft', 'is_winner')
     list_select_related = True  # For the judgement fields
     
     inlines = (JudgeAssignmentInline, ExclusionFlagInline)

--- a/apps/challenges/migrations/0026_remove_is_live.py
+++ b/apps/challenges/migrations/0026_remove_is_live.py
@@ -1,0 +1,196 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Deleting field 'Submission.is_live'
+        db.delete_column('challenges_submission', 'is_live')
+
+
+    def backwards(self, orm):
+        
+        # Adding field 'Submission.is_live'
+        db.add_column('challenges_submission', 'is_live', self.gf('django.db.models.fields.BooleanField')(default=True), keep_default=False)
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'unique': 'True', 'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'challenges.category': {
+            'Meta': {'object_name': 'Category'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '60'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '60', 'db_index': 'True'})
+        },
+        'challenges.challenge': {
+            'Meta': {'object_name': 'Challenge'},
+            'allow_voting': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'end_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'moderate': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['projects.Project']"}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '60', 'db_index': 'True'}),
+            'start_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow'}),
+            'summary': ('django.db.models.fields.TextField', [], {}),
+            'title': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '60'})
+        },
+        'challenges.exclusionflag': {
+            'Meta': {'object_name': 'ExclusionFlag'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'submission': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['challenges.Submission']"})
+        },
+        'challenges.externallink': {
+            'Meta': {'object_name': 'ExternalLink'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'submission': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['challenges.Submission']", 'null': 'True', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '255'})
+        },
+        'challenges.judgeassignment': {
+            'Meta': {'unique_together': "(('submission', 'judge'),)", 'object_name': 'JudgeAssignment'},
+            'created_on': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'judge': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['users.Profile']"}),
+            'submission': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['challenges.Submission']"})
+        },
+        'challenges.judgement': {
+            'Meta': {'unique_together': "(('submission', 'judge'),)", 'object_name': 'Judgement'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'judge': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['users.Profile']"}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'submission': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['challenges.Submission']"})
+        },
+        'challenges.judginganswer': {
+            'Meta': {'unique_together': "(('judgement', 'criterion'),)", 'object_name': 'JudgingAnswer'},
+            'criterion': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['challenges.JudgingCriterion']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'judgement': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'answers'", 'to': "orm['challenges.Judgement']"}),
+            'rating': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'challenges.judgingcriterion': {
+            'Meta': {'ordering': "('id',)", 'object_name': 'JudgingCriterion'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'max_value': ('django.db.models.fields.IntegerField', [], {'default': '10'}),
+            'min_value': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'phases': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'judgement_criteria'", 'blank': 'True', 'to': "orm['challenges.Phase']"}),
+            'question': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '250'})
+        },
+        'challenges.phase': {
+            'Meta': {'ordering': "('order',)", 'unique_together': "(('challenge', 'name'),)", 'object_name': 'Phase'},
+            'challenge': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'phases'", 'to': "orm['challenges.Challenge']"}),
+            'end_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2012, 8, 7, 10, 42, 50, 483271)'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'order': ('django.db.models.fields.IntegerField', [], {}),
+            'start_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow'})
+        },
+        'challenges.submission': {
+            'Meta': {'ordering': "['-id']", 'object_name': 'Submission'},
+            'brief_description': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['challenges.Category']"}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['users.Profile']"}),
+            'created_on': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_draft': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_winner': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'phase': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['challenges.Phase']"}),
+            'sketh_note': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '60'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'projects.project': {
+            'Meta': {'object_name': 'Project'},
+            'allow_participation': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'allow_sub_projects': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'featured': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'featured_image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'followers': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'projects_following'", 'symmetrical': 'False', 'to': "orm['users.Profile']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'long_description': ('django.db.models.fields.TextField', [], {}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'parent_project_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100', 'db_index': 'True'}),
+            'sub_project_label': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'team_members': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['users.Profile']", 'symmetrical': 'False'}),
+            'topics': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['topics.Topic']", 'symmetrical': 'False'})
+        },
+        'taggit.tag': {
+            'Meta': {'object_name': 'Tag'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100', 'db_index': 'True'})
+        },
+        'taggit.taggeditem': {
+            'Meta': {'object_name': 'TaggedItem'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'taggit_taggeditem_tagged_items'", 'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'tag': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'taggit_taggeditem_items'", 'to': "orm['taggit.Tag']"})
+        },
+        'topics.topic': {
+            'Meta': {'object_name': 'Topic'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'draft': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '250', 'null': 'True', 'blank': 'True'}),
+            'long_description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100', 'db_index': 'True'})
+        },
+        'users.profile': {
+            'Meta': {'object_name': 'Profile'},
+            'avatar': ('django.db.models.fields.files.ImageField', [], {'max_length': '250', 'null': 'True', 'blank': 'True'}),
+            'bio': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'featured': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'featured_image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['auth.User']", 'unique': 'True', 'primary_key': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '255', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['challenges']

--- a/apps/challenges/models.py
+++ b/apps/challenges/models.py
@@ -202,11 +202,6 @@ class Submission(BaseModel):
     created_on = models.DateTimeField(default=datetime.utcnow)
     
     is_winner = models.BooleanField(verbose_name=_(u'A winning entry?'), default=False)
-    """
-    The default value for this will be decided depending on it's project
-    """
-    is_live = models.BooleanField(verbose_name=_(u'Visible to the public?'),
-        default=True)
     is_draft = models.BooleanField(verbose_name=_(u'Draft?'),
         help_text=_(u"If you would like some extra time to polish your submission before making it publically then you can set it as draft. When you're ready just un-tick and it will go live"))
     
@@ -297,19 +292,6 @@ class ExclusionFlag(models.Model):
     
     def __unicode__(self):
         return unicode(self.submission)
-
-
-def submission_saved_handler(sender, instance, **kwargs):
-    """
-    Check if parent participation is set to moderate and set _is_live to False
-    """
-    if not isinstance(instance, Submission):
-        return
-    # check submissions we want to moderate don't go direct to live
-    instance.is_live = not instance.challenge.moderate
-
-
-pre_save.connect(submission_saved_handler, sender=Submission)
 
 
 class JudgingCriterion(models.Model):

--- a/apps/challenges/tests/test_models.py
+++ b/apps/challenges/tests/test_models.py
@@ -79,7 +79,6 @@ class EntriesToLive(TestCase):
         self.submission = Submission.objects.create(
             title=u'A submission to test',
             description=u'<h3>Testing bleach</h3>',
-            is_live=True,
             phase=self.phase,
             created_by=self.user.get_profile(),
             category=self.category
@@ -87,18 +86,11 @@ class EntriesToLive(TestCase):
         self.submission_marked = Submission.objects.create(
             title=u'A submission with markdown',
             description=u'I **really** like cake',
-            is_live=True,
             phase=self.phase,
             created_by=self.user.get_profile(),
             category=self.category
         )
 
-    def test_entry_hidden(self):
-        """
-        The user wants the entry to go live but it needs moderating first
-        """
-        self.assertEqual(self.submission.is_live, False)
-    
     def test_phase_unicode(self):
         """Test the string representation of a phase."""
         self.assertEqual(unicode(self.phase),
@@ -118,6 +110,7 @@ class EntriesToLive(TestCase):
         """
         self.assertEqual(self.submission_marked.description_html,
             '<p>I <strong>really</strong> like cake</p>')
+
 
 class CategoryManager(TestCase):
     


### PR DESCRIPTION
As raised in issue #18, this field used to be useful for challenges that
were to be pre-moderated, but that never happened and the implementation
prevents ever changing the field's value.
