### PR TITLE
Assignment caching

### DIFF
--- a/apps/challenges/models.py
+++ b/apps/challenges/models.py
@@ -8,7 +8,6 @@ from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.core.validators import MaxLengthValidator
 from django.db import models
-from django.db.models.signals import pre_save
 
 from tower import ugettext_lazy as _
 

--- a/settings.py
+++ b/settings.py
@@ -340,7 +340,8 @@ PUSH_CREDENTIALS = 'projects.utils.push_hub_credentials'
 
 SOUTH_TESTS_MIGRATE = False
 CACHE_BACKEND = 'caching.backends.locmem://'
-CACHE_COUNT_TIMEOUT = 60
+# Don't cache count queries at all, because there's no way to invalidate them
+CACHE_COUNT_TIMEOUT = None
 
 GRAVATAR_URL = 'https://secure.gravatar.com/avatar/'
 


### PR DESCRIPTION
Fix the [judging workflow problem](http://mozillaignite.lighthouseapp.com/projects/86804/tickets/44) by disabling caching on count queries.
