### PR TITLE
The form template now requires 'errors' to be in the context

### DIFF
--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -386,6 +386,11 @@ class EditEntryView(UpdateView, JingoTemplateMixin, SingleSubmissionMixin):
         self.object = self.get_object()
         
         context = self.get_context_data(**self.get_forms())
+        """
+        We now access errrors direct in the template - so with no errors 
+        it throws undefined
+        """
+        context['errors'] = {}
         return self.render_to_response(context)
     
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
This feels pretty dirty, but as we're accessing errors from the template (so we can display them inline) it seemed the easiest way to get in in there...

Is there a better way to have the views not now blow up?
