### PR TITLE
Merging up from dev to staging a fix for votes migration (0044)

### DIFF
--- a/apps/challenges/migrations/0044_move_votes_to_parents.py
+++ b/apps/challenges/migrations/0044_move_votes_to_parents.py
@@ -16,6 +16,11 @@ class Migration(DataMigration):
         votes = Vote.objects.filter(content_type=submission_model)
         # Iterate over the existing votes
         for vote in votes:
+            # Ignore votes that don't have a submission object
+            # Not having a object means that the submission has been
+            # removed.
+            if not vote.object:
+                continue
             # change the vote to be in the parent
             parent = vote.object.parent
             vote.object = parent


### PR DESCRIPTION
If a submission with a vote has been deleted then we have to skip over, opposed to throwing an error and blowing up the migration
