### PR TITLE
Changing 'proposals' to 'apps' and fixing a number of related bugs

### DIFF
--- a/apps/challenges/forms.py
+++ b/apps/challenges/forms.py
@@ -54,6 +54,7 @@ entry_fields = (
 # List new fields for the Submission
 development_entry_fields = entry_fields + (
     'repository_url',
+    'blog_url',
     )
 
 class EntryForm(forms.ModelForm):

--- a/apps/challenges/models.py
+++ b/apps/challenges/models.py
@@ -140,7 +140,7 @@ class Phase(BaseModel):
 
     @models.permalink
     def get_absolute_url(self):
-        slug = 'ideas' if self.is_ideation else 'proposals'
+        slug = 'ideas' if self.is_ideation else 'apps'
         return ('entries_all', [slug])
 
     @cached_property
@@ -227,7 +227,7 @@ class Phase(BaseModel):
 
     @cached_property
     def slug_url(self):
-        return 'proposals' if self.is_development else 'ideas'
+        return 'apps' if self.is_development else 'ideas'
 
 
 @receiver(signals.post_save, sender=Phase)
@@ -398,7 +398,7 @@ class Submission(BaseModel):
     def phase_slug(self):
         if self.is_idea:
             return 'ideas'
-        return 'proposals'
+        return 'apps'
 
     def get_absolute_url(self):
         """Return this submission's URL."""

--- a/apps/challenges/tests/test_integration_ignite.py
+++ b/apps/challenges/tests/test_integration_ignite.py
@@ -23,7 +23,7 @@ class SubmissionBaseTest(TestCase):
     def setUp(self):
         self.profile = create_user('bob')
         self.ideation_url = reverse('create_entry', args=['ideas'])
-        self.development_url = reverse('create_entry', args=['proposals'])
+        self.development_url = reverse('create_entry', args=['apps'])
 
     def _get_valid_data(self, **kwargs):
         defaults = {
@@ -150,7 +150,7 @@ class SubmissionEditIdeationOpenAnonTest(SubmissionBaseTest):
             ok_(item in context)
 
     def test_invalid_url_development_show_get(self):
-        url = reverse('entry_show', args=['proposals',
+        url = reverse('entry_show', args=['apps',
                                           self.submission.parent.slug])
         response = self.client.get(url)
         eq_(response.status_code, 404)
@@ -216,7 +216,7 @@ class SubmissionEditIdeationOpenTest(SubmissionBaseTest):
             eq_(item.tags, 'success')
 
     def test_invalid_development_url(self):
-        url = reverse('entry_edit', args=['proposals', self.submission.parent.slug])
+        url = reverse('entry_edit', args=['apps', self.submission.parent.slug])
         response = self.client.get(url)
         eq_(response.status_code, 403)
 
@@ -297,7 +297,7 @@ class SubmissionEditIdeationClosedAnonTest(SubmissionBaseTest):
             ok_(item in context)
 
     def test_invalid_url_development_show_get(self):
-        url = reverse('entry_show', args=['proposals',
+        url = reverse('entry_show', args=['apps',
                                           self.submission.parent.slug])
         response = self.client.get(url)
         eq_(response.status_code, 404)
@@ -362,7 +362,7 @@ class SubmissionEditIdeationClosedTest(SubmissionBaseTest):
 
     def test_invalid_development_url(self):
         url = reverse('entry_edit',
-                      args=['proposals', self.submission.parent.slug])
+                      args=['apps', self.submission.parent.slug])
         response = self.client.get(url)
         eq_(response.status_code, 403)
 
@@ -415,7 +415,7 @@ class SubmissionDevelopmentOpenTest(SubmissionBaseTest):
         data possible"""
         self.valid_data.update(BLANK_EXTERNALS)
         response = self.client.post(self.development_url, self.valid_data)
-        self.assertRedirects(response, reverse('entries_all', args=['proposals']))
+        self.assertRedirects(response, reverse('entries_all', args=['apps']))
         submission = Submission.objects.get()
         eq_(submission.phase, self.initial_data['dev_phase'])
         eq_(submission.phase_round, self.initial_data['round_a'])
@@ -424,7 +424,7 @@ class SubmissionDevelopmentOpenTest(SubmissionBaseTest):
     def test_development_phase_valid_submission_inline_links(self):
         self.valid_data.update(EXTERNALS)
         response = self.client.post(self.development_url, self.valid_data)
-        self.assertRedirects(response, reverse('entries_all', args=['proposals']))
+        self.assertRedirects(response, reverse('entries_all', args=['apps']))
         submission = Submission.objects.get()
         link = ExternalLink.objects.get()
         eq_(link.name, 'Mozilla')
@@ -450,7 +450,7 @@ class SubmissionEditDevelopmentOpenAnonTest(SubmissionBaseTest):
                                             phase=initial_data['dev_phase'],
                                             phase_round=initial_data['round_b'])
         self.edit_url = reverse('entry_edit',
-                                args=['proposals', self.submission.parent.slug])
+                                args=['apps', self.submission.parent.slug])
 
     def test_development_edit_get(self):
         response = self.client.get(self.edit_url)
@@ -461,7 +461,7 @@ class SubmissionEditDevelopmentOpenAnonTest(SubmissionBaseTest):
         self.assertRedirectsLogin(response)
 
     def test_development_show_get(self):
-        url = reverse('entry_show', args=['proposals',
+        url = reverse('entry_show', args=['apps',
                                           self.submission.parent.slug])
         response = self.client.get(url)
         eq_(response.status_code, 200)
@@ -492,7 +492,7 @@ class SubmissionEditDevelopmentOpenNotOwnerTest(SubmissionBaseTest):
                                        phase=initial_data['dev_phase'],
                                        phase_round=initial_data['round_b'])
         self.edit_url = reverse('entry_edit',
-                                args=['proposals', submission.parent.slug])
+                                args=['apps', submission.parent.slug])
         self.client.login(username='bob', password='bob')
 
     def tearDown(self):
@@ -529,7 +529,7 @@ class SubmissionEditDevelopmentOpenTest(SubmissionBaseTest):
         self.client.login(username='bob', password='bob')
 
     def _get_edit_url(self, slug):
-        return reverse('entry_edit', args=['proposals', slug])
+        return reverse('entry_edit', args=['apps', slug])
 
     def tearDown(self):
         super(SubmissionEditDevelopmentOpenTest, self).tearDown()
@@ -643,7 +643,7 @@ class SubmissionEditDevelopmentClosedRoundAnonTests(SubmissionBaseTest):
                                             phase=initial_data['dev_phase'],
                                             phase_round=initial_data['round_a'])
         self.edit_url = reverse('entry_edit',
-                                args=['proposals', self.submission.parent.slug])
+                                args=['apps', self.submission.parent.slug])
 
     def test_development_edit_get(self):
         response = self.client.get(self.edit_url)
@@ -654,7 +654,7 @@ class SubmissionEditDevelopmentClosedRoundAnonTests(SubmissionBaseTest):
         self.assertRedirectsLogin(response)
 
     def test_development_show_get(self):
-        url = reverse('entry_show', args=['proposals',
+        url = reverse('entry_show', args=['apps',
                                           self.submission.parent.slug])
         response = self.client.get(url)
         eq_(response.status_code, 200)
@@ -687,7 +687,7 @@ class SubmissionEditDevelopmentClosedRoundNotOnwerTests(SubmissionBaseTest):
                                        phase=initial_data['dev_phase'],
                                        phase_round=initial_data['round_a'])
         self.edit_url = reverse('entry_edit',
-                                args=['proposals', submission.parent.slug])
+                                args=['apps', submission.parent.slug])
         self.client.login(username='bob', password='bob')
 
     def tearDown(self):
@@ -716,7 +716,7 @@ class SubmissionEditDevelopmentClosedRoundTests(SubmissionBaseTest):
                                             phase=initial_data['dev_phase'],
                                             phase_round=initial_data['round_a'])
         self.edit_url = reverse('entry_edit',
-                                args=['proposals', self.submission.parent.slug])
+                                args=['apps', self.submission.parent.slug])
         self.client.login(username='bob', password='bob')
 
     def tearDown(self):

--- a/apps/challenges/views.py
+++ b/apps/challenges/views.py
@@ -33,11 +33,11 @@ LOGGER = logging.getLogger(__name__)
 
 def get_phase_or_404(slug):
     """Returns the appropriate ``Phase`` to the given slug
-    ``ideas`` or ``proposals`` or raise ``Http404``"""
+    ``ideas`` or ``apps`` or raise ``Http404``"""
     phase = None
     if slug == 'ideas':
         phase = Phase.objects.get_ideation_phase()
-    if slug == 'proposals':
+    if slug == 'apps':
         phase = Phase.objects.get_development_phase()
     if phase:
         return phase

--- a/apps/ignite/templates/ignite/about.html
+++ b/apps/ignite/templates/ignite/about.html
@@ -33,7 +33,7 @@
                     <p>Ideation is being judged and closed for new submissions; but the development phase will open in {{ request.development.days_until }} days.</p>
                 {% endif %}
                 {% if request.development.is_open %}
-                    <a class="cta" href="{{ url('create_entry', phase='proposals') }}">Submit your idea now</a>
+                    <a class="cta" href="{{ url('create_entry', phase='apps') }}">Submit your idea now</a>
                 {% endif %}
 			</div>
 		</div>
@@ -104,7 +104,7 @@
 					   <li><strong><a href="{{ url('create_entry', phase='ideas') }}">Submit your ideas</a>.</strong> What’s your gigabit dream app?</li>
                     {% endif %}
                     {% if request.development.is_open %}
-                       <li><strong><a href="{{ url('create_entry', phase='proposals') }}">Submit your ideas</a>.</strong> What’s your gigabit dream app?</li>
+                       <li><strong><a href="{{ url('create_entry', phase='apps') }}">Submit your ideas</a>.</strong> What’s your gigabit dream app?</li>
                     {% endif %}
 					<li><strong><a href="{{ url('entries_all', phase='ideas') }}">Check out</a></strong> ideas that have been submitted, ask questions and join the conversation.</li>
 					<li><strong>Attend</strong> an upcoming event, from instructional webcasts to in-person hackfests.</li>
@@ -204,7 +204,7 @@
 			<div class="box col">
 				<h3 class="wimper">How to apply</h3>
                 {% if request.development.is_open %}
-                    <p>To enter, assemble your team and fill out the <a href="{{ url('create_entry', phase='proposals') }}">online application form</a>.</p>
+                    <p>To enter, assemble your team and fill out the <a href="{{ url('create_entry', phase='apps') }}">online application form</a>.</p>
                 {% else %}
                     <p><strong>Development applications open August 1</strong>. To enter, assemble your team and fill out the online application form.</p>
                 {% endif %}
@@ -290,7 +290,7 @@
             <a href="{{ url('create_entry', phase='ideas') }}" class="cta">Submit your idea now</a>
         {% endif %}
         {% if request.development.is_open %}
-            <a href="{{ url('create_entry', phase='proposals') }}" class="cta">Submit your idea now</a>
+            <a href="{{ url('create_entry', phase='apps') }}" class="cta">Submit your idea now</a>
         {% endif %}
 	</footer>
     {% endif %}

--- a/apps/ignite/templates/ignite/splash.html
+++ b/apps/ignite/templates/ignite/splash.html
@@ -71,10 +71,9 @@
     <ul>
     {% for cat in categories %}
     <li class="box col {{ cat.slug }}">
-      {% if request.development.is_open %}
+      {% if request.development.has_started %}
       <a href="{{ url('entries_for_category', category=cat.slug, phase='apps') }}"><strong>{{ cat.name }}</strong></a>
-      {% endif %}
-      {% if request.ideation.is_open %}
+      {% else %}
       <a href="{{ url('entries_for_category', category=cat.slug, phase='ideas') }}"><strong>{{ cat.name }}</strong></a>
       {% endif %}
     </li>

--- a/apps/ignite/templates/ignite/splash.html
+++ b/apps/ignite/templates/ignite/splash.html
@@ -25,7 +25,7 @@
             Ideation is being judged and closed for new submissions; but the development phase will open in {{ request.development.days_until }} days
         {% endif %}
          {% if development.is_open %}
-         <a href="{{ url('create_entry', phase='proposals') }}" class="cta">create a proposal</a><br /> or <a href="{{ url('about_ignite') }}">learn more</a>
+         <a href="{{ url('create_entry', phase='apps') }}" class="cta">create an application</a><br /> or <a href="{{ url('about_ignite') }}">learn more</a>
          {% endif %}
        </div>
     </div>
@@ -37,7 +37,7 @@
                 <h3 class="exclaim">Compete</h3>
                 <p class="intro">Win funding and support to make your app a reality. <strong>$500,000 in prizes</strong> available over three rounds.</p>
                 {% if request.development.is_open %}
-                    <a class="col-foot" href="{{ url('create_entry', phase='proposals') }}">Submit your proposal</a>
+                    <a class="col-foot" href="{{ url('create_entry', phase='apps') }}">Submit your application</a>
                 {% else %}
                     <a class="col-foot" href="{{ url('about_ignite')}}">Applications open August 1</a>
                 {% endif %}
@@ -72,7 +72,7 @@
     {% for cat in categories %}
     <li class="box col {{ cat.slug }}">
       {% if request.development.is_open %}
-      <a href="{{ url('entries_for_category', category=cat.slug, phase='proposals') }}"><strong>{{ cat.name }}</strong></a>
+      <a href="{{ url('entries_for_category', category=cat.slug, phase='apps') }}"><strong>{{ cat.name }}</strong></a>
       {% endif %}
       {% if request.ideation.is_open %}
       <a href="{{ url('entries_for_category', category=cat.slug, phase='ideas') }}"><strong>{{ cat.name }}</strong></a>
@@ -108,7 +108,7 @@
                 {% endif %}
                 {% if request.development.is_open %}
                     <h2 class="point box-title">What's your app?</h2>
-                    <a class="cta" href="{{ url('create_entry', phase='proposals') }}">Get started</a>
+                    <a class="cta" href="{{ url('create_entry', phase='apps') }}">Get started</a>
                 {% endif %}
         </div>
     </div>
@@ -139,7 +139,7 @@
     <p class="intro">Discover great ideas <a href="{{ url('entries_all', phase='ideas') }}" class="cta do">See all submissions</a></p>
     {% endif %}
     {% if development.is_open %}
-    <p class="intro">Discover other applications <a href="{{ url('entries_all', phase='proposals') }}" class="cta do">See all proposals</a></p>
+    <p class="intro">Discover other applications <a href="{{ url('entries_all', phase='apps') }}" class="cta do">See all applications</a></p>
     {% endif %}
 </footer>
 {% if waffle.switch('show_blog') and waffle.switch('show_events') %}

--- a/apps/ignite/views.py
+++ b/apps/ignite/views.py
@@ -22,7 +22,7 @@ def splash(request, project, slug, template_name='ignite/splash.html'):
                                  .filter(phase__name="Development")
                                  .order_by("?"))
         num_entries = len(entries)
-        entries_from = 'proposals'
+        entries_from = 'apps'
         if num_entries < 5:
             entries = (Submission.objects.visible()
                                  .filter(phase__challenge=challenge)
@@ -71,7 +71,7 @@ def terms(request, project, slug, template_name='static/terms_conditions.html'):
 def fail(request, template_name='404.html'):
     return jingo.render(request, template_name, {}, status=404)
 
- 
+
 def app_fail(request, template_name='500.html'):
     return jingo.render(request, template_name, {}, status=500)
 

--- a/settings_test.py
+++ b/settings_test.py
@@ -19,6 +19,12 @@ DATABASES = {
     }
 }
 
+# Create the these directories off media and set to 755 so the app can access them
+USER_AVATAR_PATH = 'img/uploads/avatars/'
+TOPIC_IMAGE_PATH = 'img/uploads/topics/'
+PROJECT_IMAGE_PATH = 'img/uploads/projects/'
+EVENT_IMAGE_PATH = 'img/uploads/events/'
+CHALLENGE_IMAGE_PATH = 'img/uploads/challenges/'
 
 HMAC_KEYS = {
     '2011-01-01': 'cheesecake',

--- a/templates_ignite/base.html
+++ b/templates_ignite/base.html
@@ -34,7 +34,7 @@
                 <ul>
                     <li><a href="{{ url('about_ignite') }}">{{ _('About the challenge') }}</a></li>
                     <li><a href="{{ url('entries_all', phase='ideas') }}">{{ _('Ideas') }}</a></li>
-                    {% if development.has_started %}<li><a href="{{ url('entries_all', phase='proposals') }}">{{ _('Proposals') }}</a></li>{% endif %}
+                    {% if development.has_started %}<li><a href="{{ url('entries_all', phase='apps') }}">{{ _('Applications') }}</a></li>{% endif %}
                     {% if waffle.switch('show_judges') %}
                     <li><a href="{{ url('our_judges') }}">{{ _('Judges') }}</a></li>
                     {% endif %}

--- a/templates_ignite/challenges/all.html
+++ b/templates_ignite/challenges/all.html
@@ -16,7 +16,7 @@
   Ideas
   {% endif %}
   {% if phase.is_development %}
-  Proposals
+  Applications
   {% endif %}
   {% endblock  %}
 </h1>
@@ -40,7 +40,7 @@
       <li><a{% if not category %} class="current"{% endif %} href="{{ url('entries_all', phase='ideas') }}">All ideas</a></li>
       {% endif %}
       {% if phase.is_development %}
-      <li><a{% if not category %} class="current"{% endif %} href="{{ url('entries_all', phase='proposals') }}">All proposals</a></li>
+      <li><a{% if not category %} class="current"{% endif %} href="{{ url('entries_all', phase='apps') }}">All applications</a></li>
       {% endif %}
         {% if categories %}
         {% for cat in categories %}
@@ -57,7 +57,7 @@
 <h2 class="all">All ideas</h2>
 {% endif %}
 {% if phase.is_development %}
-<h2 class="all">All proposals</h2>
+<h2 class="all">All applications</h2>
 {% endif %}
 
 {% endif %}
@@ -120,7 +120,7 @@
 </p>
         {% endif %}
         {% if phase.is_development %}
-        <p class="point">We currently don't have any proposals for {{ category.name }} {% if phase.is_open %}- be the first to <a class="cta" href="{{ url('create_entry', phase='proposals') }}">create a proposal</a></p>{% endif %}
+        <p class="point">We currently don't have any applications for {{ category.name }} {% if phase.is_open %}- be the first to <a class="cta" href="{{ url('create_entry', phase='apps') }}">create an application</a></p>{% endif %}
 
         {% endif %}
 
@@ -130,7 +130,7 @@
 <p class="point">We currently don't have any ideas submitted for any of the focus areas - pick your favourite and be the first to <a class="cta" href="{{ url('create_entry', phase=phase.slug_url) }}">create an idea</a></p>
         {% endif %}
         {% if phase.is_development %}
-<p class="point">We currently don't have any proposal submitted for any of the focus areas - pick your favourite and be the first to <a class="cta" href="{{ url('create_entry', phase=phase.slug_url) }}">create a proposal</a></p>
+<p class="point">We currently don't have any applications submitted for any of the focus areas - pick your favourite and be the first to <a class="cta" href="{{ url('create_entry', phase=phase.slug_url) }}">create an application</a></p>
         {% endif %}
         {% endif %}
     {% endif %}
@@ -138,9 +138,9 @@
     </div>
     {% if phase.is_ideation and request.development.is_open %}
         {% if category %}
-    <p class="wimper">See what has been submitted for development - <a href="{{ url('entries_for_category', category=category.slug, phase='proposals') }}">all development proposals in {{ category.name }}</a></p>
+    <p class="wimper">See what has been submitted for development - <a href="{{ url('entries_for_category', category=category.slug, phase='apps') }}">all development applications in {{ category.name }}</a></p>
     {% else %}
-        <p class="wimper">See what has been submitted for development - <a href="{{ url('entries_all', phase='proposals') }}">all development proposals</a></p>
+        <p class="wimper">See what has been submitted for development - <a href="{{ url('entries_all', phase='apps') }}">all development applications</a></p>
     {% endif %}
   {% endif %}
   {% if phase.is_development %}

--- a/templates_ignite/challenges/create.html
+++ b/templates_ignite/challenges/create.html
@@ -25,7 +25,7 @@
 {% endif %}
 
 {% if phase.is_development %}
-<h1 class="shout">{{ _('Submit a proposal') }}</h1>
+<h1 class="shout">{{ _('Submit an application') }}</h1>
 {% endif %}
 <p class="page-intro">{{ _("Congratulations! You've taken the first step towards making the world, and the internet, a better place. Fill out the form below to get started in the Mozilla Ignite Challenge.") }}</p>
 {% endblock %}

--- a/templates_ignite/challenges/show_entry.html
+++ b/templates_ignite/challenges/show_entry.html
@@ -94,7 +94,7 @@
             {% endif %}
             {% if help_required %}
             <div class="description">
-              <h2>Would you be interested in helping with this proposal?</h2>
+              <h2>Would you be interested in helping with this application?</h2>
               <p>{{ help_required.notes }}</p>
             </div>
             {% endif %}
@@ -221,7 +221,7 @@
             {% if request.development.is_open %}
             <div class="highlight">
                 <h2 class="point box-title">How would you push the web further?</h2>
-                <a class="cta" href="{{ url('create_entry', phase='proposals') }}">Submit a proposal</a>
+                <a class="cta" href="{{ url('create_entry', phase='apps') }}">Submit an application</a>
             </div>
             {% endif %}
         </aside>

--- a/templates_ignite/challenges/show_entry.html
+++ b/templates_ignite/challenges/show_entry.html
@@ -23,18 +23,18 @@
 {% endblock %}
 
 {% block content %} 
-    <a href="{{ url('entries_all', phase=entry.phase_slug) }}" class="back wimper">See all {{ entry.phase_slug}}</a>
-    <article>
-      <h1 class="shout">{{ entry.title }}</h1>
-        {# This will need changing if edit and delete permissions separate #}
-        {% if entry.editable_by(user) %}
+<a href="{{ url('entries_all', phase=entry.phase_slug) }}" class="back wimper">See all {{ entry.phase_slug}}</a>
+<article>
+    <h1 class="shout">{{ entry.title }}</h1>
+    {# This will need changing if edit and delete permissions separate #}
+    {% if entry.editable_by(user) %}
         <ul class="user_tools">
         {% if development.has_started and entry.owned_by(user) %}
             <li><a href="{{ url('entry_help', entry_id=entry.parent.slug) }}" class="cta do">Ask for help</a></li>
             <li><a href="{{ entry.get_edit_url() }}" class="cta do">Edit your submission</a></li>
             <li><a href="{{ entry.get_delete_url() }}" class="cta do">Delete your submission</a></li>
             {% if entry.needs_booking %}
-            <li><a href="{{ url('timeslot:object_list', entry_id=entry.id) }}" class="cta do">Book a timeslot</a></li>
+                <li><a href="{{ url('timeslot:object_list', entry_id=entry.id) }}" class="cta do">Book a timeslot</a></li>
             {% endif %}
         {% else %}
             <li><a href="{{ entry.get_edit_url() }}" class="cta do">Edit this submission</a></li>
@@ -42,18 +42,18 @@
         {% endif %}
         </ul>
         {% if entry.is_draft %}
-        <div class="alerts inline">
-            <p><strong>Idea in draft</strong></p>
-            <p>This idea is not yet published. To make it public, uncheck the "Save as draft?" option.</p>
-        </div>
+            <div class="alerts inline">
+                <p><strong>Idea in draft</strong></p>
+                <p>This idea is not yet published. To make it public, uncheck the "Save as draft?" option.</p>
+            </div>
         {% endif %}
+    {% endif %}
+    <div class="columns">
+        {% if excluded %}
+            <p class="busta alerts errors">
+                {% trans %}This entry has been eliminated from judging.{% endtrans %}
+            </p>
         {% endif %}
-        <div class="columns">
-            {% if excluded %}
-                <p class="busta alerts errors">
-                    {% trans %}This entry has been eliminated from judging.{% endtrans %}
-                </p>
-                {% endif %}
         <div class="col box">
             <div class="widgets">
                 <p>Submitted on {{ entry.created_on.strftime('%B %d, %Y') }}</p>
@@ -68,35 +68,39 @@
                 <h2 class="point">The solution</h2>
                 {{ entry.description_html }}
                 {% if entry.sketh_note %}
-                <div class="frame box sketh">
-                  <img src="{{ entry.get_image_src() }}" alt="" />
-                </div>
+                    <div class="frame box sketh"><img src="{{ entry.get_image_src() }}" alt="" /></div>
                 {% endif %}
                 <h2 class="wimper">How will your idea make people's live's better?</h2>
                 <p>{{ entry.life_improvements }}</p>
                 {% if entry.take_advantage %}
-                <h2 class="wimper">How does your idea take advantage of next-generation networks?</h2>
-                <p>{{ entry.take_advantage }}</p>
+                    <h2 class="wimper">How does your idea take advantage of next-generation networks?</h2>
+                    <p>{{ entry.take_advantage }}</p>
                 {% endif %}
-    </div>
-            {% if entry.repository_url %}
-            <p><a href="{{ entry.repository_url }}">Project Repository</a></p>
-            {% endif %}
-            {% if links %}
-            <div class="links">
-            <h2 class="wimper">See also</h2>
-            <ul>
-            {% for link in links %}
-            <li><a class="wimper" href="{{ link.url }}">{{ link.name }}</a></li>
-            {% endfor %}
-            </ul> 
+                {% if entry.blog_url or entry.repository_url %}
+                    <h2 class="point">Looking for more information on this application?</h2>
+                    {% if entry.blog_url %}
+                        <p>Read about project updates</strong> - <a href="{{ entry.blog_url }}">project blog</a></p>
+                    {% endif %}
+                    {% if entry.repository_url %}
+                        <p>Take a look at the existing code - </strong><a href="{{ entry.repository_url }}">project repository</a></p>
+                    {% endif %}
+                {% endif %}
             </div>
+            {% if links %}
+                <div class="links">
+                    <h2 class="wimper">See also</h2>
+                    <ul>
+                    {% for link in links %}
+                        <li><a class="wimper" href="{{ link.url }}">{{ link.name }}</a></li>
+                    {% endfor %}
+                    </ul> 
+                </div>
             {% endif %}
             {% if help_required %}
-            <div class="description">
-              <h2>Would you be interested in helping with this application?</h2>
-              <p>{{ help_required.notes }}</p>
-            </div>
+                <div class="description">
+                    <h2>Would you be interested in helping with this application?</h2>
+                    <p>{{ help_required.notes }}</p>
+                </div>
             {% endif %}
             <address class="vcard">
                 <p class="wimper"><a class="fn url" href="{{ url('users_profile', username=entry.created_by.user.username) }}">{{ entry.created_by.name }}</a></p>
@@ -114,120 +118,120 @@
             <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
         </div>
         <aside class="col box">
-          {% if badge_list %}
-          <section>
-            <h2>Badges awarded</h2>
-            {% for object in badge_list %}
-            <p>{{ object.badge.badge_type }} {{ object.text }}</p>
-            {% endfor%}
-          </section>
-          {% endif %}
+            {% if badge_list %}
+                <section>
+                    <h2>Badges awarded</h2>
+                    {% for object in badge_list %}
+                        <p>{{ object.badge.badge_type }} {{ object.text }}</p>
+                    {% endfor%}
+                </section>
+            {% endif %}
             {% if award_form %}
-            <section class="highlight box">
-              <h2 class="point box-title">Award this submission</h2>
-              <p><b>You scored this submission {{ entry.get_judge_score(user.get_profile()) }}%</b></p>
-              <p>You can award up to ${{ allowance.amount_free }}</p>
-              <form method="post" id="form-awardform-id" action="{{ url('awards:award', submission_id=entry.id) }}">
-                {{ award_form.as_p() }}
-                {{ csrf()|safe }}
-                <p><input type="submit" value="Award Idea" class="cta"></p>
-              </form>
-            </section>
+                <section class="highlight box">
+                    <h2 class="point box-title">Award this submission</h2>
+                    <p><b>You scored this submission {{ entry.get_judge_score(user.get_profile()) }}%</b></p>
+                    <p>You can award up to ${{ allowance.amount_free }}</p>
+                    <form method="post" id="form-awardform-id" action="{{ url('awards:award', submission_id=entry.id) }}">
+                        {{ award_form.as_p() }}
+                        {{ csrf()|safe }}
+                        <p><input type="submit" value="Award Idea" class="cta"></p>
+                    </form>
+                </section>
             {% endif %}
             {% if judging_form %}
-            <section class="highlight box">
-                <form method="POST" action="{{ entry.get_judging_url() }}" class="rating_form">
-                    <h2 class="point box-title">Rate this submission</h2>
-                    {{ csrf()|safe }}
-                    {{ judging_form.as_p() }}
-                    <input type="submit" class="cta" value="Judge submission" />
-                </form>
-            </section>
+                <section class="highlight box">
+                    <form method="POST" action="{{ entry.get_judging_url() }}" class="rating_form">
+                        <h2 class="point box-title">Rate this submission</h2>
+                        {{ csrf()|safe }}
+                        {{ judging_form.as_p() }}
+                        <input type="submit" class="cta" value="Judge submission" />
+                    </form>
+                </section>
             {% endif %}
             {% if webcast_list %}
-          <section class="highlight box">
-            <h2 class="point box-title">Upcoming webcast</h2>
-            <p>Like the sounds of this idea? Why not watch their upcoming webcast(s) on:</p>
-            <ul>
-            {% for webcast in webcast_list %}
-            <li>{{ webcast.start_date.strftime('%B %d, %Y at %H:%M') }} at <a href="{{ webcast.webcast_url }}">{{ webcast.webcast_url }}</a></li>
-            {% endfor%}
-        </ul>
-          </section>
-          {% endif %}
+                <section class="highlight box">
+                    <h2 class="point box-title">Upcoming webcast</h2>
+                    <p>Like the sounds of this idea? Why not watch their upcoming webcast(s) on:</p>
+                    <ul>
+                    {% for webcast in webcast_list %}
+                        <li>{{ webcast.start_date.strftime('%B %d, %Y at %H:%M') }} at <a href="{{ webcast.webcast_url }}">{{ webcast.webcast_url }}</a></li>
+                    {% endfor%}
+                    </ul>
+                </section>
+            {% endif %}
             <section class="widgets">
                 <h2 class="wimper">Share</h2>
                 <ul class="share">
-                <li>
-                <a href="https://twitter.com/share" class="twitter-share-button" data-count="horizontal" data-via="mozilla" data-related="USignite">Tweet</a>
-                </li>
-                <li>
-                <div class="g-plusone" data-size="medium" data-url="http://www.mozillaignite.org{{ entry.get_absolute_url() }}"></div>
-                </li>
-                <li>
-                <iframe src="//www.facebook.com/plugins/like.php?href=http%3A%2F%2Fwww.mozillaignite.org{{ entry.get_absolute_url() }}&amp;send=false&amp;layout=button_count&amp;width=90&amp;show_faces=false&amp;action=like&amp;colorscheme=light&amp;font&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:90px; height:21px;" allowTransparency="true"></iframe>
-                </li>
-
+                    <li>
+                        <a href="https://twitter.com/share" class="twitter-share-button" data-count="horizontal" data-via="mozilla" data-related="USignite">Tweet</a>
+                    </li>
+                    <li>
+                        <div class="g-plusone" data-size="medium" data-url="http://www.mozillaignite.org{{ entry.get_absolute_url() }}"></div>
+                    </li>
+                    <li>
+                        <iframe src="//www.facebook.com/plugins/like.php?href=http%3A%2F%2Fwww.mozillaignite.org{{ entry.get_absolute_url() }}&amp;send=false&amp;layout=button_count&amp;width=90&amp;show_faces=false&amp;action=like&amp;colorscheme=light&amp;font&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:90px; height:21px;" allowTransparency="true"></iframe>
+                    </li>
                 </ul>
             </section>
             <section class="widgets">
                 <h2 class="wimper">Vote</h2>
                 {% if user.is_authenticated() %}
-                {% if entry.editable_by(user) %}
-                    <p><strong>Looking for more votes?</strong></p>
-                    <p>Use the social media sharing buttons above, or just get your friends to head to <em>http://www.mozillaignite.org{{ entry.get_absolute_url() }}</em></p>
+                    {% if entry.editable_by(user) %}
+                        <p><strong>Looking for more votes?</strong></p>
+                        <p>Use the social media sharing buttons above, or just get your friends to head to <em>http://www.mozillaignite.org{{ entry.get_absolute_url() }}</em></p>
+                    {% else %}
+                        {% if user_vote and user_vote.is_upvote %}
+                            <form action="{{ url('entry_vote', object_id=parent.pk, direction='clear') }}" method="POST" id="user_vote">
+                                {{ csrf()|safe }}
+                                <input type="submit" class="cancel cta do" value="{{ _('Clear my vote') }}" />
+                            </form>
+                        {% else %}
+                            <form action="{{ url('entry_vote', object_id=parent.pk, direction='up') }}" method="POST" id="user_vote">
+                                {{ csrf()|safe }}
+                                <input type="submit" class="thumb cta do" value="{{ _('Give this a thumbs up') }}" />
+                            </form>
+                        {% endif %}
+                    {% endif %}
                 {% else %}
-                {% if user_vote and user_vote.is_upvote %}
-                <form action="{{ url('entry_vote', object_id=parent.pk, direction='clear') }}" method="POST" id="user_vote">
-                    {{ csrf()|safe }}
-                    <input type="submit" class="cancel cta do" value="{{ _('Clear my vote') }}" />
-                </form>
-                {% else %}
-                <form action="{{ url('entry_vote', object_id=parent.pk, direction='up') }}" method="POST" id="user_vote">
-                    {{ csrf()|safe }}
-                    <input type="submit" class="thumb cta do" value="{{ _('Give this a thumbs up') }}" />
-                </form>
-                {% endif %}
-                {% endif %}
-                {% else %}
-                <p>To upvote this submission, please login or register for Mozilla Ignite.</p>
+                    <p>To upvote this submission, please login or register for Mozilla Ignite.</p>
                 {% endif %}
             </section>
             <section class="widgets">
                 <nav class="tags">
-                <h2 class="wimper">Focus area</h2>
-                <p><a class="{{ entry.category.slug }}"href="{{ url('entries_for_category', category=entry.category.slug, phase='ideas') }}">{{ entry.category }}</a></p>
+                    <h2 class="wimper">Focus area</h2>
+                    <p><a class="{{ entry.category.slug }}"href="{{ url('entries_for_category', category=entry.category.slug, phase='ideas') }}">{{ entry.category }}</a></p>
                 </nav>
             </section>
             <section class="widgets">
                 <nav class="browser">
-                <h2 class="wimper">More ideas</h2>
-                <ul>
-                {% if previous %}
-                    <li class="box"><a href="{{ previous.get_absolute_url() }}"><div class="frame box"><img src="{{ previous.get_image_src() }}" alt="" /></div>Previous</a></li>
-                {% endif %}
-                {% if next %}
-                    <li class="box"><a href="{{ next.get_absolute_url() }}"><div class="frame box"><img src="{{ next.get_image_src() }}" alt="" /></div>Next</a></li>
-                {% endif %}
-                </ul>
+                    <h2 class="wimper">More ideas</h2>
+                    <ul>
+                        {% if previous %}
+                            <li class="box"><a href="{{ previous.get_absolute_url() }}"><div class="frame box"><img src="{{ previous.get_image_src() }}" alt="" /></div>Previous</a></li>
+                        {% endif %}
+                        {% if next %}
+                            <li class="box"><a href="{{ next.get_absolute_url() }}"><div class="frame box"><img src="{{ next.get_image_src() }}" alt="" /></div>Next</a></li>
+                        {% endif %}
+                    </ul>
                 </nav>
             </section> 
             {% if request.ideation.is_open %}
-            <div class="highlight">
-                <h2 class="point box-title">How would you push the web further?</h2>
-                <a class="cta" href="{{ url('create_entry', phase='ideas') }}">Create an idea</a>
-            </div>
+                <div class="highlight">
+                    <h2 class="point box-title">How would you push the web further?</h2>
+                    <a class="cta" href="{{ url('create_entry', phase='ideas') }}">Create an idea</a>
+                </div>
             {% endif %}
             {% if request.development.is_open %}
-            <div class="highlight">
-                <h2 class="point box-title">How would you push the web further?</h2>
-                <a class="cta" href="{{ url('create_entry', phase='apps') }}">Submit an application</a>
-            </div>
+                <div class="highlight">
+                    <h2 class="point box-title">How would you push the web further?</h2>
+                    <a class="cta" href="{{ url('create_entry', phase='apps') }}">Submit an application</a>
+                </div>
             {% endif %}
         </aside>
-        </div>
-    </article>
+    </div>
+</article>
 {% endblock %}
+
 {% block page_js %}
 <script type="text/javascript">
     var disqus_shortname = 'mozillaignite',

--- a/templates_ignite/users/profile.html
+++ b/templates_ignite/users/profile.html
@@ -60,26 +60,26 @@
 {% endif %}
 
 {% if development_submissions %}
-    <h2 class="wimper">{{ _('Proposals') }}</h2>
+    <h2 class="wimper">{{ _('Applications') }}</h2>
     <ul class="columns submissions">
-        {% for proposal in development_submissions %}
+        {% for app in development_submissions %}
         <li class="col box">
             <article>
-            <a class="title" href="{{ proposal.get_absolute_url() }}">
+            <a class="title" href="{{ app.get_absolute_url() }}">
                 <h3 class="title wimper">
                     <div class="frame box">
-                        <img src="{{ proposal.get_image_src() }}" alt="" />
+                        <img src="{{ app.get_image_src() }}" alt="" />
                     </div>
-                    {{ proposal.title }}
+                    {{ app.title }}
                 </h3>
             </a>
             </article>
-            {% if proposal.editable_by(user) %}
-                {% if proposal.is_draft %}
+            {% if app.editable_by(user) %}
+                {% if app.is_draft %}
                     <div class="alerts inline">
-                        <p><strong>Proposal in draft</strong></p>
+                        <p><strong>Application in draft</strong></p>
                         <p>Only you can see this until you uncheck the "Save as draft?" option.</p>
-                        <a href="{{ proposal.get_edit_url() }}" class="cta do">Edit your proposal</a>
+                        <a href="{{ app.get_edit_url() }}" class="cta do">Edit your application</a>
                     </div>
                 {% endif %}
             {% endif %}
@@ -119,7 +119,7 @@
     <a href="{{ url('create_entry', phase='ideas') }}" class="cta">{{ _('Create an idea') }}</a>
     {% endif %}
     {% if development.is_open %}
-    <a href="{{ url('create_entry', phase='proposals') }}" class="cta">{{ _('Create a proposal') }}</a>
+    <a href="{{ url('create_entry', phase='apps') }}" class="cta">{{ _('Create an application') }}</a>
     {% endif %}
 
 

--- a/urls_ignite.py
+++ b/urls_ignite.py
@@ -36,7 +36,7 @@ urlpatterns = patterns(
 )
 
 
-pattern = '(?P<phase>(ideas|proposals))'
+pattern = '(?P<phase>(ideas|apps))'
 
 urlpatterns += patterns(
     'challenges.views',


### PR DESCRIPTION
- 'apps' and 'applications' are the chosen umbrella terms for the development stage submissions
- fixing the lack of categories displayed on the homepage when there is no phase open
- creating a slightly better display of the repo and blog URLs on entry pages
- adding blog_url to the list of expected development entry fields - so that it gets saved with the submission
