### PR TITLE
Using a better flag to highlight the lull between ideation closing and development opening

### DIFF
--- a/apps/ignite/templates/ignite/splash.html
+++ b/apps/ignite/templates/ignite/splash.html
@@ -88,11 +88,10 @@
 {% endif %}
 <div class="columns project_data content_columns">
     <div class="dynamic main col box">
-        {% if ideation.is_open %}
-            <p class="intro"><strong>What would you do with an Internet without limits?</strong> How can next-generation apps change the world? Share your ideas. You don't need to be a developer or technologist to participate -- at this stage we're just seeking good ideas. All are welcome!</p>
-        {% endif %}
-        {% if development.is_open %}
+        {% if development.has_started %}
             <p class="intro"><strong>What would you BUILD on an internet without limits?</strong> The laws of physics (almost) no longer apply to your piece of the spacetime continuum. It’s time to start building apps on 1 Gbps, deeply programmable networks. The Development Challenge takes place in 3 rounds over 6 months with $500K in prizes & support for teams.</p>
+        {% else %}
+            <p class="intro"><strong>What would you do with an Internet without limits?</strong> How can next-generation apps change the world? Share your ideas. You don't need to be a developer or technologist to participate -- at this stage we're just seeking good ideas. All are welcome!</p>
         {% endif %}
     </div>
 
@@ -133,12 +132,11 @@
     </li>
     {% endfor %}
 </ul>
-<footer>
-    {% if request.ideation.is_open %}
-    <p class="intro">Discover great ideas <a href="{{ url('entries_all', phase='ideas') }}" class="cta do">See all submissions</a></p>
-    {% endif %}
-    {% if development.is_open %}
+<footer>    
+    {% if development.has_started %}
     <p class="intro">Discover other applications <a href="{{ url('entries_all', phase='apps') }}" class="cta do">See all applications</a></p>
+    {% else %}
+        <p class="intro">Discover great ideas <a href="{{ url('entries_all', phase='ideas') }}" class="cta do">See all submissions</a></p>
     {% endif %}
 </footer>
 {% if waffle.switch('show_blog') and waffle.switch('show_events') %}


### PR DESCRIPTION
Using development.has_started seems to be the preferred choice here - seems less open to errors when neither is open!
