### PR TITLE
Allowing Will/Ben the possibility to hack the date but not confuse PST

### DIFF
--- a/apps/challenges/models.py
+++ b/apps/challenges/models.py
@@ -676,6 +676,9 @@ class PhaseRound(models.Model):
         time_remaining = self.end_date - now
         return time_remaining.days if time_remaining.days >= 0 else -1
 
+    # horrible but required hack - the server is GMT - display the end-date in PST
+    # this is not built to work during times when DST is in the US but not the UK
+    # and should be removed when server times are using the correct timezone
     @cached_property
     def hacked_PST_enddate(self):
         return self.end_date - relativedelta(hours=8)

--- a/apps/ignite/templates/ignite/about.html
+++ b/apps/ignite/templates/ignite/about.html
@@ -28,7 +28,11 @@
                     <p>Time to start hacking: we're offering $485,000 in prizes & support for teams over three rounds.</p>
                 {% else %}
                     {% if development.next_round %}
-                        <h3 class="point box-title">{{ request.development.next_round.start_date.strftime('%B %-d') }} through {{ request.development.next_round.end_date.strftime('%B %-d') }}: submit your app proposals or further develop your existing application.</h3>
+                        {% if waffle.switch('use_hacked_PST') %}
+                            <h3 class="point box-title">{{ request.development.next_round.start_date.strftime('%B %-d') }} through {{ request.development.next_round.hacked_PST_enddate.strftime('%B %-d') }}: submit your app proposals or further develop your existing application.</h3>
+                        {% else %}
+                            <h3 class="point box-title">{{ request.development.next_round.start_date.strftime('%B %-d') }} through {{ request.development.next_round.end_date.strftime('%B %-d') }}: submit your app proposals or further develop your existing application.</h3>
+                        {% endif %}
                         <p>Time to start hacking: we're offering $485,000 in prizes & support for teams over three rounds.</p>
                     {% else %}
                         <p class="point box-title">We're currently judging the last round, we'll soon be announcing the final winners.</p>

--- a/apps/ignite/templates/ignite/splash.html
+++ b/apps/ignite/templates/ignite/splash.html
@@ -27,8 +27,11 @@
         {% endif %}
         {% if development.is_open %}
             <a href="{{ url('create_entry', phase='apps') }}" class="cta">Apply now</a><br />
-                Apply by {{ request.development.current_round.end_date.strftime('%B %-d') }} to compete in this round
-                Apply by {{ request.development.current_round.hacked_PST_enddate.strftime('%B %-d') }} to compete in this round
+                {% if waffle.switch('use_hacked_PST') %}
+                    Apply by {{ request.development.current_round.hacked_PST_enddate.strftime('%B %-d') }} to compete in this round
+                {% else %}
+                    Apply by {{ request.development.current_round.end_date.strftime('%B %-d') }} to compete in this round
+                {% endif %}
         {% else %}
             {% if development.has_started %}
                 We're currently judging the last round, we'll soon be announcing the final winners.


### PR DESCRIPTION
We found out the server were using GMT , which means that the challenge will close early for all American users.

We can hack the date but then it would look like the challenge is closing a day later and again lead to confusion.

SO - as a short-term hack I've provided a waffle switch (use_hacked_PST) that will subtract 8 hours from the current end_date. This means we can set the challenge end_date to be April 6th, 07:59 GMT but have it display as closing at April 5th 11:59 - which is what the PST users would be expecting.
